### PR TITLE
Don't crash when image is not found

### DIFF
--- a/src/main/java/de/maxhenkel/camera/TextureCache.java
+++ b/src/main/java/de/maxhenkel/camera/TextureCache.java
@@ -36,7 +36,7 @@ public class TextureCache {
             awaitingImages.remove(uuid);
         }
 
-        ResourceLocation resourceLocation = new ResourceLocation(Main.MODID, "texures/camera/" + uuid.toString());
+        ResourceLocation resourceLocation = new ResourceLocation(Main.MODID, "textures/camera/" + uuid.toString());
         CameraTextureObject cameraTextureObject = new CameraTextureObject(resourceLocation, image);
         clientImageCache.put(uuid, cameraTextureObject);
         clientResourceCache.put(uuid, resourceLocation);

--- a/src/main/java/de/maxhenkel/camera/net/MessageImageUnavailable.java
+++ b/src/main/java/de/maxhenkel/camera/net/MessageImageUnavailable.java
@@ -2,6 +2,7 @@ package de.maxhenkel.camera.net;
 
 import de.maxhenkel.camera.TextureCache;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -23,7 +24,12 @@ public class MessageImageUnavailable implements IMessage, IMessageHandler<Messag
 
     @Override
     public IMessage onMessage(MessageImageUnavailable message, MessageContext ctx) {
-        TextureCache.instance().addImage(imgUUID, new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB));
+        try {
+            final BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+            Minecraft.getMinecraft().addScheduledTask(() -> TextureCache.instance().addImage(message.imgUUID, img));
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
         return null;
     }
 


### PR DESCRIPTION
When image is not found, the application crashes for 2 reasons:

1. The uuid is incorrect, because it's using the uuid of the handler instead of the message
2. Another error in opengl.  I didn't investigate the root cause, instead I just copied the behavior from the MessageImage handler which works fine.

I inspected all other handlers and they always use the received message.